### PR TITLE
ormolu error shows stderr

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
         const formattedText = ormolu.toString();
         return [vscode.TextEdit.replace(range, formattedText)];
       } catch (e) {
-        vscode.window.showErrorMessage("ormolu failed to format the code. " + e.stdout.toString());
+        vscode.window.showErrorMessage("ormolu failed to format the code. " + e.stderr.toString());
         console.log(e.stdout.toString());
       }
     }


### PR DESCRIPTION
Instead of showing stdout, which will be empty when ormolu fails, the
prompt will show stderr, which contains the ormolu error message as
well as the error message if ormolu is not in the PATH.