### PR TITLE
Set cwd when running ormolu

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ export function activate(context: vscode.ExtensionContext) {
       const text = document.getText(range);
       try {
         const config = vscode.workspace.getConfiguration("ormolu");
-        const ormolu = cp.execSync(config.path, { input: text });
+        const ormolu = cp.execSync(config.path, { input: text, cwd: vscode.workspace.getWorkspaceFolder(document.uri).uri.path });
         const formattedText = ormolu.toString();
         return [vscode.TextEdit.replace(range, formattedText)];
       } catch (e) {


### PR DESCRIPTION
This is useful when using the [Fourmolu](https://github.com/fourmolu/fourmolu) fork of Ormolu, which reads a `fourmolu.yaml` configuration file in the root directory of your project. If you open Code so that _its_ working directory is outside the project (i.e. `code ~/src/somewhere/not/cwd`), Fourmolu will not find the `fourmolu.yaml` file. This change fixes this by setting the current working directory of the launched process to the workspace folder that contains the document being edited.